### PR TITLE
AffineG2 introspection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "api"
 
 [features]
 default = ["std", "rand", "serde"]
-std = ["serde/std", "rand/std", "byteorder/std"]
+std = ["serde/std", "rand/std", "rand/std_rng", "byteorder/std"]
 
 [dependencies]
 byteorder = { version = "1.3.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ name = "api"
 
 [features]
 default = ["std", "rand", "serde"]
-std = ["serde/std", "rand/std", "rand/std_rng", "byteorder/std"]
+std = ["serde/std", "rand/std", "byteorder/std"]
 
 [dependencies]
 byteorder = { version = "1.3.4", default-features = false }
-rand = { version = "0.8", default-features = false, features = ["getrandom"], optional = true }
+rand = { version = "0.8", default-features = false, features = ["getrandom", "std_rng"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 
 [target."cfg(all(target_arch = \"wasm32\", target_os = \"unknown\"))".dependencies.getrandom]

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -35,7 +35,10 @@ pub fn fq2_nonresidue() -> Fq2 {
     )
 }
 
-#[cfg_attr(feature = "serde", derive(crate::maybe_serde::Serialize, crate::maybe_serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(crate::maybe_serde::Serialize, crate::maybe_serde::Deserialize)
+)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct Fq2 {
@@ -74,6 +77,16 @@ impl Fq2 {
                 c1: self.c1 * fq_non_residue(),
             }
         }
+    }
+
+    /// Real part
+    pub fn re(&self) -> Fq {
+        self.c0
+    }
+
+    /// Imaginary part
+    pub fn im(&self) -> Fq {
+        self.c1
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use rand::Rng;
 
 pub(crate) mod maybe_serde {
     #[cfg(feature = "serde")]
-    pub use serde::{Serialize, Deserialize, de::DeserializeOwned};
+    pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
     #[cfg(not(feature = "serde"))]
     pub trait Serialize {}
 
@@ -248,6 +248,14 @@ impl Fq2 {
                 .map_err(|_| FieldError::InvalidMember)?,
         ))
     }
+
+    pub fn re(&self) -> Fq {
+        Fq(self.0.re())
+    }
+
+    pub fn im(&self) -> Fq {
+        Fq(self.0.im())
+    }
 }
 
 pub trait Group:
@@ -311,6 +319,14 @@ pub struct AffineG2(groups::AffineG2);
 impl AffineG2 {
     pub fn new(x: Fq2, y: Fq2) -> Result<Self, AffineGError> {
         Ok(AffineG2(groups::AffineG2::new(x.0, y.0)?))
+    }
+
+    pub fn x(&self) -> Fq2 {
+        Fq2(*self.0.x())
+    }
+
+    pub fn y(&self) -> Fq2 {
+        Fq2(*self.0.y())
     }
 
     pub fn from_jacobian(g2: G2) -> Option<Self> {


### PR DESCRIPTION
The adds a few methods to be able to look at the component parts of elements of `AffineG2`. This introspection will allow us to pass the elements into NEAR's alt_bn128 pairing host function, which will soon be stabilized in nearcore.

To see how these functions are used see https://github.com/birchmd/aurora-engine/blob/794aa48a2ec4949b7af3375ecd02d2db198a0246/engine-precompiles/src/bn128.rs#L364-L383

This PR also fixes the compilation of the tests and fixes some formatting (see https://github.com/aurora-is-near/aurora-bn/commit/81ef5d670e87186f52f3bcd379d2acae3833ab38 and https://github.com/aurora-is-near/aurora-bn/commit/97d30973f71c3087b52794571ad6d783c901ce30 )